### PR TITLE
로그아웃 버그

### DIFF
--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -53,8 +53,7 @@ class LoginAPIView(APIView):
 # 로그아웃 기능  
 class LogoutAPIvie(APIView):
     def post(self, request):
-        request.user.auth_token.delete()
-        logout(request)
+            # 토큰을 따로 DB에 저장을 안 하기 때문에 블랙리스트방식을 못 써서 클라이언트측에서 토큰을 삭제하는 방식으로 해야함
         return Response(
             {
                 "message": "logout success",


### PR DESCRIPTION
- request.user.auth_token.delete() 이부분을 지우고 로그아웃 할 때 블랙리스트 방식을 사용을 안해서 토큰 삭제는 클라이언트에서 하는게 맞다 따라서 로그아웃할 때 msg만 보내는 로직으로 바꿈

close #77 